### PR TITLE
Restructure repo to Android-only: move android/ to root, remove all other code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,15 @@
-dgp.db
-seed
-.eggs/
+# Local Android SDK path — machine-specific
+local.properties
+
+# Gradle build outputs and caches
 build/
+.gradle/
+
+# Android build artifacts
+*.apk
+*.aab
+*.ap_
+
+# IDE files
+.idea/
+*.iml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,11 +32,11 @@ dgp/
 │           └── security/
 │               ├── BiometricHelper.kt      # Android Keystore + biometric encryption
 │               └── ConfigCrypto.kt         # PBKDF2+AES-GCM config encryption
-├── gradle/wrapper/
+├── gradle/wrapper/                         # Gradle wrapper (intentionally checked in)
 ├── build.gradle                            # Root Gradle build script
 ├── settings.gradle                         # rootProject.name = "DGP", includes :app
-├── gradle.properties                       # AndroidX, Jetifier, JVM args, JDK path
-├── local.properties                        # Android SDK path (gitignored)
+├── gradle.properties                       # AndroidX, Jetifier, JVM args, JDK path (checked in)
+├── local.properties                        # Android SDK path (gitignored, machine-specific)
 ├── gradlew / gradlew.bat
 └── CLAUDE.md
 ```
@@ -51,7 +51,7 @@ dgp/
 
 **Requirements:** JDK 21, Android SDK (path set in `local.properties`), Android SDK 34.
 
-The Gradle wrapper is pre-configured. `gradle.properties` sets `org.gradle.java.home=/usr/lib/jvm/java-21-openjdk`.
+The Gradle wrapper (`gradle/wrapper/`) is intentionally checked into version control — standard Android practice that allows any developer to build without installing Gradle separately. `gradle.properties` is also checked in; it configures project-wide settings (AndroidX, Jetifier, JVM memory, JDK path). The only machine-specific file is `local.properties` (Android SDK path), which is gitignored.
 
 ## Architecture
 
@@ -125,7 +125,7 @@ Run from the app UI via the test button in settings.
 
 1. **Never change PBKDF2 parameters** (SHA1, 42000 iterations) — breaks compatibility with all existing stored passwords.
 2. **Test vectors are the source of truth** — any algorithm change must pass all vectors in `TestVectors.kt`.
-3. **No new storage** — passwords are never stored; they're always re-derived from seed + account + service.
+3. **Generated passwords are never stored** — always re-derived on demand from seed + account + service. Other data (service configs, account field) may be stored encrypted.
 4. **Seed security** — seed must remain in memory only while unlocked; always clear on lock/reboot.
 5. **Error handling in crypto** — `ConfigCrypto.decrypt()` returns `null` on failure; callers must handle gracefully.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,77 +4,139 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What is DGP?
 
-DGP (Deterministically Generated Passwords) is a password manager that derives passwords from a seed + secret using PBKDF2. It has three implementations:
+DGP (Deterministically Generated Passwords) is an Android password manager that derives passwords deterministically from a **seed + account secret + service name** using PBKDF2. Given the same inputs, it always produces the same password — no database of stored passwords is needed.
 
-1. **Flask web app** (`dgp/`) — the primary application
-2. **C CLI tool** (`dgp-simple.c`) — standalone command-line version using OpenSSL
-3. **Android app** (`android/`) — Kotlin port with biometric unlock
+The repository was restructured in commit `62985ad` to be **Android-only**. All Python (Flask web app, `simple.py`), C CLI (`dgp-simple.c`), and related tooling were removed. The Android app, previously in `android/`, now lives at the repository root.
 
-All implementations must produce identical output for the same inputs. The core algorithm: `PBKDF2(seed + secret, service_name)` → output in various formats (hex, base58, alnum, xkcd wordlist).
+Historical implementations exist in git history:
+- **Flask web app** — `dgp/blueprints/engine.py`, SHA256/8192 iterations
+- **C CLI tool** — `dgp-simple.c`, SHA256/260000 iterations
+- **Standalone Python** — `simple.py`, SHA1/42000 iterations
+
+## Repository Structure
+
+```
+dgp/
+├── app/
+│   ├── build.gradle                        # App-level Gradle config
+│   ├── proguard-rules.pro
+│   └── src/main/
+│       ├── AndroidManifest.xml
+│       ├── assets/
+│       │   └── english.txt                 # BIP-39 2048-word list (for xkcd format)
+│       └── java/com/dgp/
+│           ├── MainActivity.kt             # Jetpack Compose UI (795 lines)
+│           ├── engine/
+│           │   ├── DgpEngine.kt            # Password generation algorithm
+│           │   └── TestVectors.kt          # 50+ hardcoded test vectors
+│           └── security/
+│               ├── BiometricHelper.kt      # Android Keystore + biometric encryption
+│               └── ConfigCrypto.kt         # PBKDF2+AES-GCM config encryption
+├── gradle/wrapper/
+├── build.gradle                            # Root Gradle build script
+├── settings.gradle                         # rootProject.name = "DGP", includes :app
+├── gradle.properties                       # AndroidX, Jetifier, JVM args, JDK path
+├── local.properties                        # Android SDK path (gitignored)
+├── gradlew / gradlew.bat
+└── CLAUDE.md
+```
 
 ## Build & Run Commands
 
-### Flask Web App
 ```bash
-pip install --editable .
-export FLASK_APP="dgp.factory:create_app()"
-flask initdb          # initialize SQLite database
-flask run             # runs on http://localhost:5000/
+./gradlew assembleDebug      # build debug APK (requires JDK 21)
+./gradlew assembleRelease    # build release APK
+./gradlew build              # full build including tests
 ```
 
-### Tests
-```bash
-pytest tests/                    # run all Python tests
-pytest tests/test_dgp.py::test_login_logout  # single test
-```
+**Requirements:** JDK 21, Android SDK (path set in `local.properties`), Android SDK 34.
 
-### C CLI Tools
-```bash
-make dgp-simple       # requires libcrypto (OpenSSL)
-make genseed
-# Or via CMake:
-cmake -B build && cmake --build build
-ctest --test-dir build  # runs tests/basic.sh
-```
-
-### Standalone CLI (Python)
-```bash
-python simple.py test-vectors                          # print test vectors
-python simple.py <seed> <account> <name> <type>        # generate a password
-```
-
-### Android
-```bash
-cd android && ./gradlew assembleDebug    # requires JDK 21
-```
+The Gradle wrapper is pre-configured. `gradle.properties` sets `org.gradle.java.home=/usr/lib/jvm/java-21-openjdk`.
 
 ## Architecture
 
-### Password Generation Pipeline
-- **Web app engine**: `dgp/blueprints/engine.py` — uses `hashlib.pbkdf2_hmac('sha256', ..., iterations=8192)`
-- **Standalone Python**: `simple.py` — uses PBKDF2 with SHA1, 42000 iterations (different params than web engine!)
-- **C implementation**: `dgp-simple.c` — uses OpenSSL EVP, SHA256, 260000 iterations
-- **Android/Kotlin**: `android/.../DgpEngine.kt` — uses PBKDF2WithHmacSHA1, 42000 iterations
+### Password Generation Algorithm (`app/src/main/java/com/dgp/engine/DgpEngine.kt`)
 
-**Warning**: The implementations use different hash functions and iteration counts. `simple.py` and the Android app use SHA1/42000 iterations. The web engine uses SHA256/8192 iterations. The C tool uses SHA256/260000 iterations. Be careful when modifying generation logic.
+- **Algorithm:** PBKDF2-HMAC-SHA1
+- **Iterations:** 42,000
+- **Key length:** 40 bytes
+- **Key material:** `seed + account` (concatenated)
+- **Salt:** `service_name`
 
-### Output Formats
-All implementations support: `hex`, `hexlong`, `alnum`, `alnumlong`, `base58`, `base58long`, `xkcd`, `xkcdlong`. The `alnum` format uses base58 encoding and ensures the result contains uppercase, lowercase, and digits. The `xkcd` format uses `english.txt` (BIP-39 2048-word list).
+Output formats (all derived from the same 40-byte key):
 
-### Flask App Structure
-- `dgp/factory.py` — app factory with WSGI middleware chain (ReverseProxied → HTTPSRedirect → SecurityHeaders)
-- `dgp/blueprints/dgp.py` — routes: `/login`, `/register`, `/logout`, `/add`, `/gen`, `/custom`
-- `dgp/auth.py` — user auth with PBKDF2-SHA256 password hashing (260000 iterations)
-- `dgp/schema.sql` — SQLite schema (users, entries tables)
-- `dgp/blueprints/engine.py` — password generation engine
-- Seed is read from a file at `dgp/seed`
+| Format | Description |
+|--------|-------------|
+| `hex` | First 16 bytes as hex (32 chars) |
+| `hexlong` | All 40 bytes as hex (80 chars) |
+| `base58` | Base58-encoded, 20 bytes |
+| `base58long` | Base58-encoded, 40 bytes |
+| `alnum` | Base58 subset enforcing uppercase + lowercase + digit |
+| `alnumlong` | Long alnum variant |
+| `xkcd` | 4 words from BIP-39 list |
+| `xkcdlong` | 6 words from BIP-39 list |
 
-### Key Files
-- `english.txt` — BIP-39 wordlist (root dir), also symlinked/copied in `dgp/english.txt`
-- `seed` — user's seed file (gitignored, must be created manually)
-- `dgp.db` — SQLite database (gitignored, created by `flask initdb`)
+Base58 alphabet: `123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz`
 
-## Configuration
-- `DGP_SETTINGS` env var points to a Python config file
-- `HTTPS_REDIRECT` and `SESSION_COOKIE_SECURE` env vars for production
-- See `DEPLOYMENT.md` for production setup (Nginx, Gunicorn, systemd)
+`alnum` format: generates multiple base58 passwords until one satisfies uppercase + lowercase + digit requirements.
+
+`xkcd` format: uses BigInteger arithmetic to index into `english.txt` (2048 words, BIP-39).
+
+### Security Architecture (`app/src/main/java/com/dgp/security/`)
+
+**BiometricHelper.kt** — Seed encryption at rest:
+- AES-256-GCM via Android Keystore with biometric requirement
+- Key invalidated on new biometric enrollment
+- Stores: IV (12 bytes) + ciphertext
+- Falls back gracefully on older devices
+
+**ConfigCrypto.kt** — Service config + account encryption:
+- PBKDF2-HMAC-SHA256, 100,000 iterations, key derived from seed
+- AES-256-GCM encryption
+- Stores Base64(IV + ciphertext) in SharedPreferences
+- Account field cleared on reboot and biometric failure
+
+### UI (`app/src/main/java/com/dgp/MainActivity.kt`)
+
+Jetpack Compose, Material3. Key UI states:
+- **Locked** — seed entry dialog (manual or biometric unlock)
+- **Unlocked** — service list with search, add/edit/delete
+- **Generate** — account prompt → password display with clipboard copy
+- **Settings** — seed management (change, export QR, import via camera QR scan)
+- **Test vectors** — runs all 50+ test vectors with pass/fail UI
+
+External dependency: `com.google.android.gms:play-services-code-scanner` for QR code import.
+
+Sensitive data handling:
+- `ClipboardManager` uses `EXTRA_IS_SENSITIVE = true` (Android 13+)
+- Account field persisted encrypted with seed, cleared on reboot
+
+### Test Vectors (`app/src/main/java/com/dgp/engine/TestVectors.kt`)
+
+50+ hardcoded input/output pairs covering:
+- 64-byte and 65-byte seeds (64-byte triggers pre-hashing in some implementations)
+- Empty account string
+- Various service name lengths
+- All 8 output formats
+
+Run from the app UI via the test button in settings.
+
+## Key Conventions
+
+1. **Never change PBKDF2 parameters** (SHA1, 42000 iterations) — breaks compatibility with all existing stored passwords.
+2. **Test vectors are the source of truth** — any algorithm change must pass all vectors in `TestVectors.kt`.
+3. **No new storage** — passwords are never stored; they're always re-derived from seed + account + service.
+4. **Seed security** — seed must remain in memory only while unlocked; always clear on lock/reboot.
+5. **Error handling in crypto** — `ConfigCrypto.decrypt()` returns `null` on failure; callers must handle gracefully.
+
+## Dependencies (app/build.gradle)
+
+- `androidx.core:core-ktx:1.12.0`
+- `androidx.lifecycle:lifecycle-runtime-ktx:2.7.0`
+- `androidx.activity:activity-compose:1.8.2`
+- `androidx.compose:compose-bom:2023.10.01` (UI, Material3)
+- `androidx.biometric:biometric:1.1.0`
+- `androidx.compose.material:material-icons-extended`
+- `com.google.android.gms:play-services-code-scanner:16.1.0`
+
+Min SDK: 26 (Android 8.0), Target SDK: 34, Kotlin 1.9.22, Compose compiler 1.5.8.

--- a/README.md
+++ b/README.md
@@ -1,54 +1,35 @@
                          / Dgp /
 
-                 Determinstically Generated Passwords
+                 Deterministically Generated Passwords
 
 
     ~ What is Dgp?
 
-      A sqlite powered wrapper for:
-      pbkdf2_hex(seed+secret, service_name, iterations=8192)
-      and other password output formats (base58, xkcd, etc.)
+      An Android password manager that derives passwords deterministically
+      from a seed + account + service name using PBKDF2-HMAC-SHA1 (42,000
+      iterations). The same inputs always produce the same password — no
+      password database is stored or synced.
 
-    ~ How do I use it?
 
-      1. edit the configuration in the factory.py file or
-         export a DGP_SETTINGS environment variable
-         pointing to a configuration file or pass in a
-         dictionary with config values using the create_app
-         function.
+    ~ How does it work?
 
-      2. install the app from the root of the project directory
+      key = PBKDF2(seed + account, service_name, iterations=42000)
 
-         pip install --editable .
+      Output formats: hex, base58, alnum, xkcd wordlist, and long variants.
+      The seed is encrypted at rest using AES-256-GCM via the Android
+      Keystore, protected by biometric authentication.
 
-      3. instruct flask to use the right application
 
-         export FLASK_APP="dgp.factory:create_app()"
+    ~ How do I build it?
 
-      4. initialize the database with this command:
+      Requirements: JDK 21, Android SDK 34
 
-         flask initdb
+      ./gradlew assembleDebug     # debug APK
+      ./gradlew assembleRelease   # release APK
 
-      4b. Write a seed file:
-
-         echo "My seed which I also wrote down somewhere safe" > seed
-
-      5. now you can run dgp:
-
-         flask run
-
-         the application will greet you on
-         http://localhost:5000/
-
-    ~ Other "installation" instructions
-
-         Since the above did not work for me:
-         pip install .
-         export FLASK_APP=standalone.py
-         flask initdb
-         flask run
 
     ~ Is it tested?
 
-      Nope :)
-      Run `python setup.py test` to see the old tests fail.
+      Yes. 50+ test vectors are built into the app and can be run from
+      the settings screen. They validate all output formats and edge cases
+      (including 64-byte seed pre-hashing).


### PR DESCRIPTION
Moves all Android app files from android/ subdirectory to the repository root,
making this a standalone Android project. Removes the Flask web app, C CLI tools,
Python utilities, and all associated tests and config files.

https://claude.ai/code/session_0147g2HCsodSQCFpqdsvGvRM